### PR TITLE
Additional query filters, parallel queries and changelog query added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
-
 # Changelog
+
+## 0.2.0
+
+* `region_name`, `tenant` and `tag` properties added to the query filter
+* `device_site`, `device_region` and `device_tags` properties added to the version output
+* `use_changelog` option added to use the NetBox changelog. See the documentation for details and performance considerations
+* `parallel_queries` option added to speed up the check process by running multiple queries in parallel
+* golang version updated to `1.25.7`
+
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A concourse resource to trigger from netbox
 This resource is built using a Dockerfile that uses a multi-stage build process. The first stage builds the Go application, and the second stage creates a minimal container image using distroless. The following optional build arguments are available:
 
 - `BUILDER_NAME`: The name of the Go builder image (default: `golang`)
-- `BUILDER_VERSION`: The version of the Go builder image (default: `1.24.4-bookworm`)
-- `BASE_NAME`: The base image for the final container (default: `gcr.io/distroless/static-debian12`)
+- `BUILDER_VERSION`: The version of the Go builder image (default: `1.25.0-bookworm`)
+- `BASE_NAME`: The base image for the final container (default: `gcr.io/distroless/static-debian13`)
 - `BASE_VERSION`: The version of the base image (default: `latest`) (`nonroot` is not possible because Concourse [requires root permissions to run the resource](https://github.com/concourse/concourse/issues/403))
 
 The following build arguments are mandatory:
@@ -32,7 +32,50 @@ This resource is designed to be used in a Concourse CI pipeline. It can be confi
 
 ### Configuration
 
-The `source.url` parameter is mandatory. All fields in the `source.filter` section and the `source.token` are optional. Fields with brackets `[]` can contain multiple values. `source.filter.device_name` and `source.filter.interface_name` are using a `case-insensitive contains` filter. The `source.filter.get_config_context` parameter can be set to `true` to include the device's config context in the output. Because of the current limitation in the go-netbox library the config context is gathered with every query, but only included in the output if this parameter is set to `true`.
+#### Source Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `url` | *(none)* | The URL of the NetBox instance (mandatory) |
+| `token` | *(none)* | The API token for authentication |
+| `parallel_queries` | `1` | Number of parallel queries to NetBox. Can speed up the check process, but be careful not to overload your NetBox instance |
+| `use_changelog` | `false` | Use the NetBox changelog to determine which devices have interface changes. More efficient than querying all devices, but it may miss changes without a changelog entry |
+| `initial_lookback` | *(epoch 0)* | Initial lookback timeframe for the first check (when no version exists) using Go duration format (e.g., `168h` for 7 days, `720h30m` for 30 days 30 minutes, `8760h` for 1 year). Supports: `h` (hours), `m` (minutes), `s` (seconds), and combinations like `1h30m45s`. If not specified, defaults to Unix epoch (1970-01-01) returning all matching objects |
+
+> **Warning:** When `use_changelog` is enabled with filters like `tenant`, `site_name`, or `region_name`, performance may be significantly slower than the classic query. The changelog API fetches all change events globally and filters afterward, while the classic query applies filters directly at the API level. Use `use_changelog: false` (default) for better performance when filtering by tenant or other device attributes.
+
+#### Filter Parameters
+
+All filter parameters are optional and can be used in combination to narrow down the devices and interfaces that trigger the resource. If no filters are provided, all devices and their interfaces will be considered.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `filter.site_name` | `[]` | Filter devices by site name(s) |
+| `filter.region_name` | `[]` | Filter devices by region name(s) |
+| `filter.tenant` | `[]` | Filter devices by tenant slug(s) (e.g., `my-tenant`) |
+| `filter.tag` | `[]` | Filter devices by tag slug(s) |
+| `filter.role` | `[]` | Filter devices by role slug(s) |
+| `filter.device_id` | `[]` | Filter devices by device ID(s) |
+| `filter.device_name` | `[]` | Filter devices by name (case-insensitive contains) |
+| `filter.device_type` | `[]` | Filter devices by device type(s) |
+| `filter.device_status` | `[]` | Filter devices by status (e.g., `active`, `planned`) |
+| `filter.get_config_context` | `false` | Include the device's config context in the output |
+
+#### Server Interface Filter Parameters
+
+Additional filters can be applied to the server interfaces of the devices. These filters will be applied after filtering the devices, so they will only affect the interfaces of the already filtered devices.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `filter.server_interface.interface_id` | `[]` | Filter interfaces by interface ID(s) |
+| `filter.server_interface.interface_name` | `[]` | Filter interfaces by name (case-insensitive contains) |
+| `filter.server_interface.enabled` | *(none)* | Filter interfaces by enabled state |
+| `filter.server_interface.mgmt_only` | *(none)* | Filter interfaces by management-only flag |
+| `filter.server_interface.connected` | *(none)* | Filter interfaces by connected state |
+| `filter.server_interface.cabled` | *(none)* | Filter interfaces by cabled state |
+| `filter.server_interface.type` | `[]` | Filter interfaces by type(s) (e.g., `virtual`, `1000base-t`) |
+
+#### Example Configuration
 
 This is an example of how to configure the resource in a Concourse pipeline:
 
@@ -52,9 +95,14 @@ resources:
     check_every: 15m
     source:
       url: "https://netbox.example.local"
-      token: "your-api-token"
+      token: "your-api-token",
+      parallel_queries: 1,
+      use_changelog: false,
+      initial_lookback: "168h30m",
       filter:
         site_name: ["site 1"]
+        region_name: ["region 1"]
+        tenant: ["my-tenant"]
         tag: ["tag1"]
         role: ["server"]
         device_id: [123]

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/sapcc/concourse-netbox-resource
 
-go 1.25.4
+go 1.25.7
 
 require github.com/netbox-community/go-netbox/v4 v4.2.2-3

--- a/internal/app/check.go
+++ b/internal/app/check.go
@@ -21,10 +21,15 @@ The output will be a JSON array of objects with their latest versions.
 {
   "source": {
     "url": "https://netbox.example.local",
-    "token": "your-api-token"
+    "token": "your-api-token",
+		"parallel_queries": 4,
+    "use_changelog": true,
+		"initial_lookback": "168h30m"
 		},
 		"filter": {
 			"site_name": ["My Site"],
+			"region_name": ["My Region"],
+			"tenant": ["My Tenant"],
 			"tag": ["my-tag"],
 			"role": ["server"],
 			"device_id": [123],

--- a/internal/concourse/types.go
+++ b/internal/concourse/types.go
@@ -15,9 +15,12 @@ type Output struct {
 }
 
 type Source struct {
-	Url    string              `json:"url"`
-	Token  string              `json:"token,omitempty"`
-	Filter filter.NetboxObject `json:"filter,omitempty"`
+	Url             string              `json:"url"`
+	Token           string              `json:"token,omitempty"`
+	ParallelQueries int                 `json:"parallel_queries,omitempty"`
+	UseChangelog    *bool               `json:"use_changelog,omitempty"`
+	InitialLookback string              `json:"initial_lookback,omitempty"`
+	Filter          filter.NetboxObject `json:"filter"`
 }
 
 type Version struct {
@@ -27,6 +30,9 @@ type Version struct {
 	DeviceId            string `json:"device_id,omitempty"`
 	DeviceName          string `json:"device_name"`
 	DeviceRole          string `json:"device_role"`
+	DeviceSite          string `json:"device_site"`
+	DeviceRegion        string `json:"device_region,omitempty"`
+	DeviceTags          string `json:"device_tags,omitempty"`
 	DeviceApiUrl        string `json:"device_api_url,omitempty"`
 	DeviceDisplayUrl    string `json:"device_display_url,omitempty"`
 	ConfigContext       string `json:"config_context,omitempty"`

--- a/internal/filter/netbox.go
+++ b/internal/filter/netbox.go
@@ -2,13 +2,15 @@ package filter
 
 type NetboxObject struct {
 	SiteName         []string        `json:"site_name,omitempty"`
+	RegionName       []string        `json:"region_name,omitempty"`
+	Tenant           []string        `json:"tenant,omitempty"`
 	Tag              []string        `json:"tag,omitempty"`
 	Role             []string        `json:"role,omitempty"`
 	DeviceId         []int32         `json:"device_id,omitempty"`
 	DeviceName       []string        `json:"device_name,omitempty"`
 	DeviceType       []string        `json:"device_type,omitempty"`
 	DeviceStatus     []string        `json:"device_status,omitempty"`
-	ServerInterface  ServerInterface `json:"server_interface,omitempty"`
+	ServerInterface  ServerInterface `json:"server_interface"`
 	GetConfigContext *bool           `json:"get_config_context,omitempty"`
 }
 

--- a/internal/helper/tests.go
+++ b/internal/helper/tests.go
@@ -99,6 +99,8 @@ var (
 	DeviceDisplayUrl string = "http://netbox.example.local/dcim/devices"
 	DeviceRoleId     int32  = 8
 	DeviceRoleSlug   string = "server"
+	DeviceSiteId     int32  = 1
+	DeviceSiteSlug   string = "test-site"
 )
 
 func EnsureFolder(path string) error {

--- a/internal/netbox/changelog.go
+++ b/internal/netbox/changelog.go
@@ -1,0 +1,304 @@
+package netbox
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/netbox-community/go-netbox/v4"
+	"github.com/sapcc/concourse-netbox-resource/internal/filter"
+)
+
+// queryDevicesFromChangelog queries devices based on changelog events.
+// If queryInterfaces is true, it queries dcim.interface events and extracts device IDs.
+// If queryInterfaces is false, it queries dcim.device events directly.
+func queryDevicesFromChangelog(client *netbox.APIClient, netboxFilter filter.NetboxObject, lastUpdatedGte *time.Time, queryInterfaces bool, parallelQueries int, ctx context.Context) ([]netbox.DeviceWithConfigContext, error) {
+	if lastUpdatedGte == nil {
+		return nil, fmt.Errorf("lastUpdatedGte is required for changelog-based queries")
+	}
+
+	var deviceIds []int32
+	var err error
+
+	if queryInterfaces {
+		// Get device IDs from interface changelog
+		deviceIds, err = getDeviceIdsFromInterfaceChangelog(client, *lastUpdatedGte, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error getting device IDs from interface changelog: %w", err)
+		}
+	} else {
+		// Get device IDs from device changelog
+		deviceIds, err = getDeviceIdsFromDeviceChangelog(client, *lastUpdatedGte, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error getting device IDs from device changelog: %w", err)
+		}
+	}
+
+	if len(deviceIds) == 0 {
+		return []netbox.DeviceWithConfigContext{}, nil
+	}
+
+	// Fetch devices by IDs in batches
+	devices, err := fetchDevicesByIds(client, netboxFilter, deviceIds, parallelQueries, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching devices by IDs: %w", err)
+	}
+
+	return devices, nil
+}
+
+// fetchDevicesByIds fetches devices by their IDs, applying additional filters and batching for performance.
+func fetchDevicesByIds(client *netbox.APIClient, netboxFilter filter.NetboxObject, deviceIds []int32, parallelQueries int, ctx context.Context) ([]netbox.DeviceWithConfigContext, error) {
+	if len(deviceIds) == 0 {
+		return []netbox.DeviceWithConfigContext{}, nil
+	}
+
+	// Batch device IDs into chunks to avoid overwhelming the server
+	batchSize := 512
+	var batches [][]int32
+	for i := 0; i < len(deviceIds); i += batchSize {
+		end := min(i+batchSize, len(deviceIds))
+		batches = append(batches, deviceIds[i:end])
+	}
+
+	type batchResult struct {
+		devices  []netbox.DeviceWithConfigContext
+		err      error
+		batchIdx int
+	}
+
+	semaphore := make(chan struct{}, parallelQueries)
+	resultsChan := make(chan batchResult, len(batches))
+
+	var wg sync.WaitGroup
+	for idx, batchIds := range batches {
+		wg.Add(1)
+		go func(idx int, batchIds []int32) {
+			defer wg.Done()
+			semaphore <- struct{}{}        // Acquire
+			defer func() { <-semaphore }() // Release
+
+			var batchDevices []netbox.DeviceWithConfigContext
+			limit := int32(512)
+			offset := int32(0)
+
+			for {
+				// Create query with device IDs and apply other filters
+				query := client.DcimAPI.DcimDevicesList(ctx).Id(batchIds).Limit(limit).Offset(offset)
+
+				// Apply additional filters
+				if len(netboxFilter.SiteName) > 0 {
+					query = query.Site(netboxFilter.SiteName)
+				}
+				if len(netboxFilter.RegionName) > 0 {
+					query = query.Region(netboxFilter.RegionName)
+				}
+				if len(netboxFilter.Tenant) > 0 {
+					query = query.Tenant(netboxFilter.Tenant)
+				}
+				if len(netboxFilter.Tag) > 0 {
+					query = query.Tag(netboxFilter.Tag)
+				}
+				if len(netboxFilter.Role) > 0 {
+					query = query.Role(netboxFilter.Role)
+				}
+				if len(netboxFilter.DeviceName) > 0 {
+					query = query.NameIc(netboxFilter.DeviceName)
+				}
+				if len(netboxFilter.DeviceType) > 0 {
+					query = query.DeviceType(netboxFilter.DeviceType)
+				}
+				if len(netboxFilter.DeviceStatus) > 0 {
+					query = query.Status(netboxFilter.DeviceStatus)
+				}
+
+				response, _, err := query.Execute()
+				if err != nil {
+					resultsChan <- batchResult{err: err, batchIdx: idx}
+					return
+				}
+
+				batchDevices = append(batchDevices, response.Results...)
+
+				if !response.Next.IsSet() || response.Next.Get() == nil || *response.Next.Get() == "" || len(response.Results) == 0 {
+					break
+				}
+				offset += limit
+			}
+
+			resultsChan <- batchResult{devices: batchDevices, batchIdx: idx}
+		}(idx, batchIds)
+	}
+
+	// Wait for all goroutines to complete and close the results channel
+	go func() {
+		wg.Wait()
+		close(resultsChan)
+	}()
+
+	// Collect results
+	allDevices := make([]netbox.DeviceWithConfigContext, 0, len(deviceIds))
+	for result := range resultsChan {
+		if result.err != nil {
+			return nil, fmt.Errorf("error fetching devices (batch %d): %w", result.batchIdx, result.err)
+		}
+		allDevices = append(allDevices, result.devices...)
+	}
+
+	return allDevices, nil
+}
+
+// getDeviceIdsFromInterfaceChangelog queries the NetBox changelog for interface changes
+// since a certain time and returns the unique device IDs affected by those changes.
+func getDeviceIdsFromInterfaceChangelog(client *netbox.APIClient, sinceTime time.Time, ctx context.Context) ([]int32, error) {
+	deviceIdSet := make(map[int32]struct{})
+
+	limit := int32(512)
+	offset := int32(0)
+
+	for {
+		query := client.CoreAPI.CoreObjectChangesList(ctx).
+			ChangedObjectType("dcim.interface").
+			TimeAfter(sinceTime).
+			Limit(limit).
+			Offset(offset)
+
+		response, _, err := query.Execute()
+		if err != nil {
+			return nil, fmt.Errorf("error querying interface changelog: %w", err)
+		}
+
+		for _, change := range response.Results {
+			// Extract device ID from PostchangeData or PrechangeData
+			deviceId := extractDeviceIdFromInterfaceChange(change)
+			if deviceId > 0 {
+				deviceIdSet[deviceId] = struct{}{}
+			}
+		}
+
+		// Check if there are more pages
+		if !response.Next.IsSet() || response.Next.Get() == nil || *response.Next.Get() == "" || len(response.Results) == 0 {
+			break
+		}
+		offset += limit
+	}
+
+	return slices.Collect(maps.Keys(deviceIdSet)), nil
+}
+
+// getDeviceIdsFromDeviceChangelog queries the NetBox changelog for device changes
+// since a certain time and returns the unique device IDs.
+func getDeviceIdsFromDeviceChangelog(client *netbox.APIClient, sinceTime time.Time, ctx context.Context) ([]int32, error) {
+	deviceIdSet := make(map[int32]struct{})
+
+	limit := int32(512)
+	offset := int32(0)
+
+	for {
+		query := client.CoreAPI.CoreObjectChangesList(ctx).
+			ChangedObjectType("dcim.device").
+			TimeAfter(sinceTime).
+			Limit(limit).
+			Offset(offset)
+
+		response, _, err := query.Execute()
+		if err != nil {
+			return nil, fmt.Errorf("error querying device changelog: %w", err)
+		}
+
+		for _, change := range response.Results {
+			// For device changes, the ChangedObjectId is the device ID
+			deviceId := int32(change.GetChangedObjectId())
+			if deviceId > 0 {
+				deviceIdSet[deviceId] = struct{}{}
+			}
+		}
+
+		// Check if there are more pages
+		if !response.Next.IsSet() || response.Next.Get() == nil || *response.Next.Get() == "" || len(response.Results) == 0 {
+			break
+		}
+		offset += limit
+	}
+
+	return slices.Collect(maps.Keys(deviceIdSet)), nil
+}
+
+// extractDeviceIdFromInterfaceChange extracts the device ID from an ObjectChange's data.
+// For interface changes, the device ID can be found in:
+// 1. ChangedObject (the interface object itself with device reference)
+// 2. PostchangeData (for create/update - contains the interface data)
+// 3. PrechangeData (for delete - contains the interface data before deletion)
+func extractDeviceIdFromInterfaceChange(change netbox.ObjectChange) int32 {
+	// Try ChangedObject first - this is the actual interface object
+	if change.HasChangedObject() {
+		changedObj := change.GetChangedObject()
+		if deviceId := extractDeviceIdFromMap(changedObj); deviceId > 0 {
+			return deviceId
+		}
+	}
+
+	// Try PostchangeData (for create/update)
+	if change.HasPostchangeData() {
+		postData := change.GetPostchangeData()
+		if deviceId := extractDeviceIdFromMap(postData); deviceId > 0 {
+			return deviceId
+		}
+	}
+
+	// Try PrechangeData (for delete operations)
+	if change.HasPrechangeData() {
+		preData := change.GetPrechangeData()
+		if deviceId := extractDeviceIdFromMap(preData); deviceId > 0 {
+			return deviceId
+		}
+	}
+
+	return 0
+}
+
+// extractDeviceIdFromMap extracts the device ID from a changelog data map.
+// The interface data contains a "device" field with the device ID.
+func extractDeviceIdFromMap(data any) int32 {
+	dataMap, ok := data.(map[string]any)
+	if !ok {
+		return 0
+	}
+
+	// Interface changes have a "device" field containing the device ID
+	deviceField, exists := dataMap["device"]
+	if !exists {
+		return 0
+	}
+
+	// Handle different possible formats
+	switch v := deviceField.(type) {
+	case float64:
+		return int32(v)
+	case int:
+		return int32(v)
+	case int32:
+		return v
+	case int64:
+		return int32(v)
+	case map[string]any:
+		// If device is an object with an "id" field
+		if id, ok := v["id"]; ok {
+			switch idVal := id.(type) {
+			case float64:
+				return int32(idVal)
+			case int:
+				return int32(idVal)
+			case int32:
+				return idVal
+			case int64:
+				return int32(idVal)
+			}
+		}
+	}
+
+	return 0
+}

--- a/internal/netbox/config_context_test.go
+++ b/internal/netbox/config_context_test.go
@@ -1,6 +1,7 @@
 package netbox
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -27,6 +28,10 @@ func TestConfigContextParsing(t *testing.T) {
 	role.SetId(helper.DeviceRoleId)
 	role.SetSlug(helper.DeviceRoleSlug)
 
+	site := netbox.BriefSite{}
+	site.SetId(helper.DeviceSiteId)
+	site.SetSlug(helper.DeviceSiteSlug)
+
 	device.Id = helper.DeviceId
 	device.Url = helper.DeviceApiUrl + fmt.Sprintf("/%d/", device.Id)
 	device.Display = helper.DeviceName
@@ -34,6 +39,7 @@ func TestConfigContextParsing(t *testing.T) {
 	device.DisplayUrl = &displayUrl
 	device.LastUpdated = updatedTime
 	device.Role = role
+	device.Site = site
 	device.SetConfigContext(helper.NetBoxConfigContextData)
 
 	// Test cases
@@ -71,7 +77,7 @@ func TestConfigContextParsing(t *testing.T) {
 			}
 
 			currentDevice := *device
-			result, err := populateDeviceDetails(helper.DeviceName, input, currentDevice)
+			result, err := populateDeviceDetails(helper.DeviceName, input, currentDevice, nil, context.Background())
 			if err != nil {
 				t.Fatalf("Error in populateDeviceDetails: %v", err)
 			}

--- a/internal/netbox/date.go
+++ b/internal/netbox/date.go
@@ -1,0 +1,57 @@
+package netbox
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/netbox-community/go-netbox/v4"
+	"github.com/sapcc/concourse-netbox-resource/internal/concourse"
+)
+
+func getReferenceTime(input concourse.Input) (time.Time, error) {
+	// If version.last_updated is provided, use it
+	if input.Version.LastUpdated != "" {
+		referenceTime, err := time.Parse(time.RFC3339, input.Version.LastUpdated)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid reference time format found in 'version.last_updated': %w", err)
+		}
+		return referenceTime.UTC(), nil
+	}
+
+	// If source.initial_lookback is provided, calculate time from now
+	if input.Source.InitialLookback != "" {
+		lookbackDuration, err := time.ParseDuration(input.Source.InitialLookback)
+		if err != nil {
+			return time.Time{}, fmt.Errorf("invalid lookback duration format (use Go duration format like 168h, 720h): %w", err)
+		}
+		return time.Now().UTC().Add(-lookbackDuration), nil
+	}
+
+	// Default to epoch 0 if neither is provided
+	return time.Unix(0, 0).UTC(), nil
+}
+
+func getTimestamps(device any, input concourse.Input, fallbackReferenceTime *time.Time) (*time.Time, time.Time, error) {
+	switch device := device.(type) {
+	case netbox.DeviceWithConfigContext:
+		lastUpdatedTime = device.LastUpdated.Get()
+	case netbox.Interface:
+		lastUpdatedTime = device.LastUpdated.Get()
+	default:
+		return &time.Time{}, time.Time{}, fmt.Errorf("unexpected device type in getTimestamps: %T", device)
+	}
+
+	// Get reference time from input, or use fallback if not provided
+	if input.Version.LastUpdated != "" {
+		referenceTime, err = getReferenceTime(input)
+		if err != nil {
+			return &time.Time{}, time.Time{}, fmt.Errorf("error parsing netbox lastupdated timestamp because of: %w", err)
+		}
+	} else if fallbackReferenceTime != nil {
+		referenceTime = *fallbackReferenceTime
+	} else {
+		referenceTime = time.Time{}
+	}
+
+	return lastUpdatedTime, referenceTime, nil
+}

--- a/internal/netbox/device.go
+++ b/internal/netbox/device.go
@@ -1,0 +1,240 @@
+package netbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/netbox-community/go-netbox/v4"
+	"github.com/sapcc/concourse-netbox-resource/internal/concourse"
+	"github.com/sapcc/concourse-netbox-resource/internal/filter"
+)
+
+// runDeviceQueriesByRegion runs device queries for each region with limited parallelism
+func runDeviceQueriesByRegion(client *netbox.APIClient, netboxFilter filter.NetboxObject, lastUpdatedGte *time.Time, regions []string, parallelQueries int, ctx context.Context) ([]netbox.DeviceWithConfigContext, error) {
+	type regionResult struct {
+		devices []netbox.DeviceWithConfigContext
+		err     error
+		region  string
+	}
+
+	semaphore := make(chan struct{}, parallelQueries)
+	resultsChan := make(chan regionResult, len(regions))
+
+	var wg sync.WaitGroup
+	for _, region := range regions {
+		wg.Add(1)
+		go func(region string) {
+			defer wg.Done()
+			semaphore <- struct{}{}        // Acquire
+			defer func() { <-semaphore }() // Release
+
+			// Create a copy of the filter with the specific region
+			regionFilter := netboxFilter
+			regionFilter.RegionName = []string{region}
+
+			devices, err := runPagedDeviceQuery(client, regionFilter, lastUpdatedGte, ctx)
+			resultsChan <- regionResult{devices: devices, err: err, region: region}
+		}(region)
+	}
+
+	// Wait for all goroutines to complete and close the results channel
+	go func() {
+		wg.Wait()
+		close(resultsChan)
+	}()
+
+	// Collect results
+	allDevices := make([]netbox.DeviceWithConfigContext, 0, 512)
+	for result := range resultsChan {
+		if result.err != nil {
+			return nil, fmt.Errorf("error querying devices for region %s: %w", result.region, result.err)
+		}
+		allDevices = append(allDevices, result.devices...)
+	}
+
+	return allDevices, nil
+}
+
+func createDeviceQuery(client *netbox.APIClient, netboxFilter filter.NetboxObject, lastUpdatedGte *time.Time, ctx context.Context) netbox.ApiDcimDevicesListRequest {
+	query := client.DcimAPI.DcimDevicesList(ctx)
+	if len(netboxFilter.SiteName) > 0 {
+		query = query.Site(netboxFilter.SiteName)
+	}
+	if len(netboxFilter.RegionName) > 0 {
+		query = query.Region(netboxFilter.RegionName)
+	}
+	if len(netboxFilter.Tenant) > 0 {
+		query = query.Tenant(netboxFilter.Tenant)
+	}
+	if len(netboxFilter.Tag) > 0 {
+		query = query.Tag(netboxFilter.Tag)
+	}
+	if len(netboxFilter.Role) > 0 {
+		query = query.Role(netboxFilter.Role)
+	}
+	if len(netboxFilter.DeviceId) > 0 {
+		query = query.Id(netboxFilter.DeviceId)
+	}
+	if len(netboxFilter.DeviceName) > 0 {
+		query = query.NameIc(netboxFilter.DeviceName)
+	}
+	if len(netboxFilter.DeviceType) > 0 {
+		query = query.DeviceType(netboxFilter.DeviceType)
+	}
+	if len(netboxFilter.DeviceStatus) > 0 {
+		query = query.Status(netboxFilter.DeviceStatus)
+	}
+	if lastUpdatedGte != nil {
+		query = query.LastUpdatedGte([]time.Time{*lastUpdatedGte})
+	}
+	return query
+}
+
+func runPagedDeviceQuery(client *netbox.APIClient, netboxFilter filter.NetboxObject, lastUpdatedGte *time.Time, ctx context.Context) ([]netbox.DeviceWithConfigContext, error) {
+	deviceList := make([]netbox.DeviceWithConfigContext, 0, 512)
+	limit := int32(512)
+	offset := int32(0)
+	for {
+		pagedQuery := createDeviceQuery(client, netboxFilter, lastUpdatedGte, ctx).Limit(limit).Offset(offset)
+		deviceQueryResponse, _, err := pagedQuery.Execute()
+		if err != nil {
+			return nil, fmt.Errorf("error during DcimDevicesList query: %w", err)
+		}
+		deviceList = append(deviceList, deviceQueryResponse.Results...)
+		if !deviceQueryResponse.Next.IsSet() || deviceQueryResponse.Next.Get() == nil || *deviceQueryResponse.Next.Get() == "" || len(deviceQueryResponse.Results) == 0 {
+			break
+		}
+		offset += limit
+	}
+	return deviceList, nil
+}
+
+func fetchDetailsFromDeviceList(input concourse.Input, deviceList []netbox.DeviceWithConfigContext, lastUpdatedGte *time.Time, parallelQueries int, ctx context.Context) ([]concourse.Version, error) {
+	output = make([]concourse.Version, 0, len(deviceList))
+
+	// Collect device IDs that need interface queries
+	deviceIdsNeedingInterfaces := make([]int32, 0)
+	for _, d := range deviceList {
+		if serverInterfaceOptionIsSet(d, netboxFilter) {
+			deviceIdsNeedingInterfaces = append(deviceIdsNeedingInterfaces, d.Id)
+		}
+	}
+
+	// Bulk fetch all interfaces at once
+	interfacesByDevice, err := runBulkInterfaceQuery(client, netboxFilter, deviceIdsNeedingInterfaces, lastUpdatedGte, parallelQueries, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error during bulk interface query: %w", err)
+	}
+
+	for _, d := range deviceList {
+		name := ""
+		if d.Name.IsSet() && d.Name.Get() != nil {
+			name = *d.Name.Get()
+		}
+		if serverInterfaceOptionIsSet(d, netboxFilter) {
+			interfaceList, hasInterfaces := interfacesByDevice[d.Id]
+			// Skip devices with no changed interfaces
+			if !hasInterfaces || len(interfaceList) == 0 {
+				continue
+			}
+			output, err = populateInterfaceDetails(name, input, d, interfaceList, lastUpdatedGte, ctx)
+			if err != nil {
+				return nil, fmt.Errorf("error during server interface details query: %w", err)
+			}
+		} else {
+			output, err = populateDeviceDetails(name, input, d, lastUpdatedGte, ctx)
+			if err != nil {
+				return nil, fmt.Errorf("error during device details query: %w", err)
+			}
+		}
+	}
+	// Sort the output by LastUpdated in ascending order
+	slices.SortStableFunc(output, func(a, b concourse.Version) int {
+		return strings.Compare(a.LastUpdated, b.LastUpdated)
+	})
+	return output, nil
+}
+
+func populateDeviceDetails(name string, input concourse.Input, device netbox.DeviceWithConfigContext, fallbackReferenceTime *time.Time, ctx context.Context) ([]concourse.Version, error) {
+	lastUpdatedTime, referenceTime, err = getTimestamps(device, input, fallbackReferenceTime)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing netbox timestamps because of: %w", err)
+	}
+
+	if lastUpdatedTime.UTC().After(referenceTime) {
+		configContext := ""
+		if input.Source.Filter.GetConfigContext != nil && *input.Source.Filter.GetConfigContext {
+			if device.HasConfigContext() {
+				configContextData := device.GetConfigContext()
+				if configContextBytes, err := json.Marshal(configContextData); err == nil {
+					configContext = string(configContextBytes)
+				}
+			}
+		}
+
+		displayUrl := ""
+		if device.DisplayUrl != nil {
+			displayUrl = *device.DisplayUrl
+		}
+
+		deviceRegion := getSiteRegion(device.Site.GetId())
+		deviceTags := getDeviceTags(device)
+
+		output = append(output, concourse.Version{
+			Id:               fmt.Sprintf("%d", device.Id),
+			LastUpdated:      lastUpdatedTime.Format(time.RFC3339),
+			ObjectType:       "devices",
+			DeviceName:       name,
+			DeviceRole:       device.Role.GetSlug(),
+			DeviceSite:       device.Site.GetSlug(),
+			DeviceRegion:     deviceRegion,
+			DeviceTags:       deviceTags,
+			DeviceApiUrl:     device.Url,
+			DeviceDisplayUrl: displayUrl,
+			ConfigContext:    configContext,
+		})
+	}
+	return output, nil
+}
+
+func serverInterfaceOptionIsSet(device netbox.DeviceWithConfigContext, netboxFilter filter.NetboxObject) bool {
+	sIf := netboxFilter.ServerInterface
+	// Check if interface filters are set
+	interfaceFiltersSet := len(sIf.InterfaceId) > 0 ||
+		len(sIf.InterfaceName) > 0 ||
+		sIf.Enabled != nil ||
+		sIf.MgmtOnly != nil ||
+		sIf.Connected != nil ||
+		sIf.Cabled != nil ||
+		len(sIf.Type) > 0
+
+	if !interfaceFiltersSet {
+		return false
+	}
+
+	// If role filter is specified, check if device role matches any of them
+	// If no role filter, apply interface query to all devices
+	if len(netboxFilter.Role) > 0 {
+		deviceRole := device.Role.GetSlug()
+		return slices.Contains(netboxFilter.Role, deviceRole)
+	}
+
+	return true
+}
+
+func getDeviceTags(device netbox.DeviceWithConfigContext) string {
+	tags := device.GetTags()
+	if len(tags) == 0 {
+		return ""
+	}
+	tagSlugs := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		tagSlugs = append(tagSlugs, tag.GetSlug())
+	}
+	return strings.Join(tagSlugs, ",")
+}

--- a/internal/netbox/nic.go
+++ b/internal/netbox/nic.go
@@ -1,0 +1,180 @@
+package netbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/netbox-community/go-netbox/v4"
+	"github.com/sapcc/concourse-netbox-resource/internal/concourse"
+	"github.com/sapcc/concourse-netbox-resource/internal/filter"
+)
+
+func createInterfaceQuery(client *netbox.APIClient, netboxFilter filter.NetboxObject, lastUpdatedGte *time.Time, ctx context.Context) netbox.ApiDcimInterfacesListRequest {
+	query := client.DcimAPI.DcimInterfacesList(ctx)
+	if len(netboxFilter.ServerInterface.InterfaceId) > 0 {
+		query = query.Id(netboxFilter.ServerInterface.InterfaceId)
+	}
+	if len(netboxFilter.ServerInterface.InterfaceName) > 0 {
+		query = query.NameIc(netboxFilter.ServerInterface.InterfaceName)
+	}
+	if netboxFilter.ServerInterface.Enabled != nil {
+		query = query.Enabled(*netboxFilter.ServerInterface.Enabled)
+	}
+	if netboxFilter.ServerInterface.MgmtOnly != nil {
+		query = query.MgmtOnly(*netboxFilter.ServerInterface.MgmtOnly)
+	}
+	if netboxFilter.ServerInterface.Connected != nil {
+		query = query.Connected(*netboxFilter.ServerInterface.Connected)
+	}
+	if netboxFilter.ServerInterface.Cabled != nil {
+		query = query.Cabled(*netboxFilter.ServerInterface.Cabled)
+	}
+	if len(netboxFilter.ServerInterface.Type) > 0 {
+		query = query.TypeIc(netboxFilter.ServerInterface.Type)
+	}
+	if lastUpdatedGte != nil {
+		query = query.LastUpdatedGte([]time.Time{*lastUpdatedGte})
+	}
+	return query
+}
+
+func runBulkInterfaceQuery(client *netbox.APIClient, netboxFilter filter.NetboxObject, deviceIds []int32, lastUpdatedGte *time.Time, parallelQueries int, ctx context.Context) (map[int32][]netbox.Interface, error) {
+	interfacesByDevice := make(map[int32][]netbox.Interface)
+	if len(deviceIds) == 0 {
+		return interfacesByDevice, nil
+	}
+
+	// Batch device IDs into chunks of 512 to avoid overwhelming the server
+	batchSize := 512
+	var batches [][]int32
+	for i := 0; i < len(deviceIds); i += batchSize {
+		end := min(i+batchSize, len(deviceIds))
+		batches = append(batches, deviceIds[i:end])
+	}
+
+	type batchResult struct {
+		interfaces []netbox.Interface
+		err        error
+		batchIdx   int
+	}
+
+	semaphore := make(chan struct{}, parallelQueries)
+	resultsChan := make(chan batchResult, len(batches))
+
+	var wg sync.WaitGroup
+	for idx, batchDeviceIds := range batches {
+		wg.Add(1)
+		go func(idx int, batchDeviceIds []int32) {
+			defer wg.Done()
+			semaphore <- struct{}{}        // Acquire
+			defer func() { <-semaphore }() // Release
+
+			var batchInterfaces []netbox.Interface
+			limit := int32(512)
+			offset := int32(0)
+			for {
+				pagedQuery := createInterfaceQuery(client, netboxFilter, lastUpdatedGte, ctx).DeviceId(batchDeviceIds).Limit(limit).Offset(offset)
+				interfaceQueryResponse, _, err := pagedQuery.Execute()
+				if err != nil {
+					resultsChan <- batchResult{err: err, batchIdx: idx}
+					return
+				}
+				batchInterfaces = append(batchInterfaces, interfaceQueryResponse.Results...)
+				if !interfaceQueryResponse.Next.IsSet() || interfaceQueryResponse.Next.Get() == nil || *interfaceQueryResponse.Next.Get() == "" || len(interfaceQueryResponse.Results) == 0 {
+					break
+				}
+				offset += limit
+			}
+			resultsChan <- batchResult{interfaces: batchInterfaces, batchIdx: idx}
+		}(idx, batchDeviceIds)
+	}
+
+	// Wait for all goroutines to complete and close the results channel
+	go func() {
+		wg.Wait()
+		close(resultsChan)
+	}()
+
+	// Collect results
+	for result := range resultsChan {
+		if result.err != nil {
+			return nil, fmt.Errorf("error during DcimInterfacesList query (batch %d): %w", result.batchIdx, result.err)
+		}
+		for _, iface := range result.interfaces {
+			deviceId := iface.Device.GetId()
+			interfacesByDevice[deviceId] = append(interfacesByDevice[deviceId], iface)
+		}
+	}
+	return interfacesByDevice, nil
+}
+
+func populateInterfaceDetails(name string, input concourse.Input, device netbox.DeviceWithConfigContext, interfaceList []netbox.Interface, fallbackReferenceTime *time.Time, ctx context.Context) ([]concourse.Version, error) {
+	for _, iface := range interfaceList {
+		// Use the interface's last_updated timestamp, not the device's
+		lastUpdatedTime, referenceTime, err = getTimestamps(iface, input, fallbackReferenceTime)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing netbox timestamps because of: %w", err)
+		}
+
+		if lastUpdatedTime.UTC().After(referenceTime) {
+			configContext := ""
+			if input.Source.Filter.GetConfigContext != nil && *input.Source.Filter.GetConfigContext {
+				if device.HasConfigContext() {
+					configContextData := device.GetConfigContext()
+					if configContextBytes, err := json.Marshal(configContextData); err == nil {
+						configContext = string(configContextBytes)
+					}
+				}
+			}
+
+			deviceDisplayUrl := ""
+			if device.DisplayUrl != nil {
+				deviceDisplayUrl = *device.DisplayUrl
+			}
+
+			interfaceDisplayUrl := ""
+			if iface.DisplayUrl != nil {
+				interfaceDisplayUrl = *iface.DisplayUrl
+			}
+
+			deviceRegion := getSiteRegion(device.Site.GetId())
+			deviceTags := getDeviceTags(device)
+
+			output = append(output, concourse.Version{
+				Id:                  fmt.Sprintf("%d", iface.Id),
+				LastUpdated:         lastUpdatedTime.Format(time.RFC3339),
+				ObjectType:          "interfaces",
+				DeviceId:            fmt.Sprintf("%d", device.Id),
+				DeviceName:          name,
+				DeviceRole:          device.Role.GetSlug(),
+				DeviceSite:          device.Site.GetSlug(),
+				DeviceRegion:        deviceRegion,
+				DeviceTags:          deviceTags,
+				DeviceApiUrl:        device.Url,
+				DeviceDisplayUrl:    deviceDisplayUrl,
+				ConfigContext:       configContext,
+				InterfaceName:       iface.Name,
+				InterfaceType:       string(iface.Type.GetLabel()),
+				InterfaceApiUrl:     iface.Url,
+				InterfaceDisplayUrl: interfaceDisplayUrl,
+			})
+		}
+	}
+	return output, nil
+}
+
+// interfaceFilterIsSet checks if any interface filter options are configured
+// Used to determine if we should query interfaces (and skip lastUpdatedGte on devices)
+func interfaceFilterIsSet(netboxFilter filter.NetboxObject) bool {
+	sIf := netboxFilter.ServerInterface
+	return len(sIf.InterfaceId) > 0 ||
+		len(sIf.InterfaceName) > 0 ||
+		sIf.Enabled != nil ||
+		sIf.MgmtOnly != nil ||
+		sIf.Connected != nil ||
+		sIf.Cabled != nil ||
+		len(sIf.Type) > 0
+}

--- a/internal/netbox/query.go
+++ b/internal/netbox/query.go
@@ -2,10 +2,7 @@ package netbox
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"slices"
-	"strings"
 	"time"
 
 	"github.com/netbox-community/go-netbox/v4"
@@ -20,281 +17,84 @@ var (
 	referenceTime   time.Time
 	output          []concourse.Version
 	err             error
+	siteRegionCache map[int32]string
 )
 
 func Query(input concourse.Input, ctx context.Context) ([]concourse.Version, error) {
 	var (
-		deviceList []netbox.DeviceWithConfigContext
+		deviceList     []netbox.DeviceWithConfigContext
+		err            error
+		lastUpdatedGte *time.Time
 	)
 
 	netboxFilter = input.Source.Filter
 	client = netbox.NewAPIClientFor(input.Source.Url, input.Source.Token)
 
-	deviceList, err = runPagedDeviceQuery(client, netboxFilter, ctx)
+	// Parse lastUpdated timestamp for filtering
+	// If not provided, use initial_lookback or epoch 0
+	parsedTime, err := getReferenceTime(input)
 	if err != nil {
-		return nil, fmt.Errorf("error during device query: %w", err)
+		return nil, fmt.Errorf("error parsing reference time: %w", err)
+	}
+	lastUpdatedGte = &parsedTime
+
+	// Determine parallelism - default to 1 if not specified
+	parallelQueries := getParallelQueries(input.Source.ParallelQueries)
+
+	// First fetch site regions - this is fast and gives us region list
+	siteRegionCache, err = fetchSiteRegions(client, netboxFilter, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error during site region query: %w", err)
 	}
 
-	output, err = fetchDetailsFromDeviceList(input, deviceList, ctx)
+	// Check if changelog-based query mode is enabled
+	if useChangelog(input) {
+		// Changelog-based query: find devices from changelog events
+		// If interface filters are set, query interface change events
+		// Otherwise, query device change events
+		queryInterfaces := interfaceFilterIsSet(netboxFilter)
+		deviceList, err = queryDevicesFromChangelog(client, netboxFilter, lastUpdatedGte, queryInterfaces, parallelQueries, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error during changelog-based device query: %w", err)
+		}
+	} else {
+		// Classic query mode
+		// Determine if we're querying interfaces
+		// If so, we need all devices (no lastUpdatedGte) but filter interfaces by lastUpdatedGte
+		// If not, we filter devices by lastUpdatedGte
+		interfaceQueryMode := interfaceFilterIsSet(netboxFilter)
+		var deviceLastUpdatedGte *time.Time
+		if !interfaceQueryMode {
+			deviceLastUpdatedGte = lastUpdatedGte
+		}
+
+		// Get unique regions from the site cache
+		regions := getUniqueRegions(siteRegionCache, netboxFilter)
+
+		// Run device queries per region with configured parallelism
+		deviceList, err = runDeviceQueriesByRegion(client, netboxFilter, deviceLastUpdatedGte, regions, parallelQueries, ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error during device query: %w", err)
+		}
+	}
+
+	output, err = fetchDetailsFromDeviceList(input, deviceList, lastUpdatedGte, parallelQueries, ctx)
 	if err != nil {
 		return nil, fmt.Errorf("error during device details query: %w", err)
 	}
 	return output, nil
 }
 
-func createDeviceQuery(client *netbox.APIClient, netboxFilter filter.NetboxObject, ctx context.Context) netbox.ApiDcimDevicesListRequest {
-	query := client.DcimAPI.DcimDevicesList(ctx)
-	if len(netboxFilter.SiteName) > 0 {
-		query = query.Site(netboxFilter.SiteName)
+// getParallelQueries returns the number of parallel queries to use.
+// Defaults to 1 if not specified or invalid.
+func getParallelQueries(configured int) int {
+	if configured <= 0 {
+		return 1
 	}
-	if len(netboxFilter.Tag) > 0 {
-		query = query.Tag(netboxFilter.Tag)
-	}
-	if len(netboxFilter.Role) > 0 {
-		query = query.Role(netboxFilter.Role)
-	}
-	if len(netboxFilter.DeviceId) > 0 {
-		query = query.Id(netboxFilter.DeviceId)
-	}
-	if len(netboxFilter.DeviceName) > 0 {
-		query = query.NameIc(netboxFilter.DeviceName)
-	}
-	if len(netboxFilter.DeviceType) > 0 {
-		query = query.DeviceType(netboxFilter.DeviceType)
-	}
-	if len(netboxFilter.DeviceStatus) > 0 {
-		query = query.Status(netboxFilter.DeviceStatus)
-	}
-	return query
+	return configured
 }
 
-func createInterfaceQuery(client *netbox.APIClient, netboxFilter filter.NetboxObject, ctx context.Context) netbox.ApiDcimInterfacesListRequest {
-	query := client.DcimAPI.DcimInterfacesList(ctx)
-	if len(netboxFilter.ServerInterface.InterfaceId) > 0 {
-		query = query.Id(netboxFilter.ServerInterface.InterfaceId)
-	}
-	if len(netboxFilter.ServerInterface.InterfaceName) > 0 {
-		query = query.NameIc(netboxFilter.ServerInterface.InterfaceName)
-	}
-	if netboxFilter.ServerInterface.Enabled != nil {
-		query = query.Enabled(*netboxFilter.ServerInterface.Enabled)
-	}
-	if netboxFilter.ServerInterface.MgmtOnly != nil {
-		query = query.MgmtOnly(*netboxFilter.ServerInterface.MgmtOnly)
-	}
-	if netboxFilter.ServerInterface.Connected != nil {
-		query = query.Connected(*netboxFilter.ServerInterface.Connected)
-	}
-	if netboxFilter.ServerInterface.Cabled != nil {
-		query = query.Cabled(*netboxFilter.ServerInterface.Cabled)
-	}
-	if len(netboxFilter.ServerInterface.Type) > 0 {
-		query = query.TypeIc(netboxFilter.ServerInterface.Type)
-	}
-	return query
-}
-
-func runPagedDeviceQuery(client *netbox.APIClient, netboxFilter filter.NetboxObject, ctx context.Context) ([]netbox.DeviceWithConfigContext, error) {
-	deviceList := make([]netbox.DeviceWithConfigContext, 0, 25)
-	limit := int32(25)
-	offset := int32(0)
-	for {
-		pagedQuery := createDeviceQuery(client, netboxFilter, ctx).Limit(limit).Offset(offset)
-		deviceQueryResponse, _, err := pagedQuery.Execute()
-		if err != nil {
-			return nil, fmt.Errorf("error during DcimDevicesList query: %w", err)
-		}
-		deviceList = append(deviceList, deviceQueryResponse.Results...)
-		if !deviceQueryResponse.Next.IsSet() || deviceQueryResponse.Next.Get() == nil || *deviceQueryResponse.Next.Get() == "" || len(deviceQueryResponse.Results) == 0 {
-			break
-		}
-		offset += limit
-	}
-	return deviceList, nil
-}
-
-func runPagedInterfaceQuery(client *netbox.APIClient, netboxFilter filter.NetboxObject, deviceId int32, ctx context.Context) ([]netbox.Interface, error) {
-	interfaceList := make([]netbox.Interface, 0, 25)
-	limit := int32(25)
-	offset := int32(0)
-	for {
-		pagedQuery := createInterfaceQuery(client, netboxFilter, ctx).DeviceId([]int32{deviceId}).Limit(limit).Offset(offset)
-		interfaceQueryResponse, _, err := pagedQuery.Execute()
-		if err != nil {
-			return nil, fmt.Errorf("error during DcimInterfacesList query: %w", err)
-		}
-		interfaceList = append(interfaceList, interfaceQueryResponse.Results...)
-		if !interfaceQueryResponse.Next.IsSet() || interfaceQueryResponse.Next.Get() == nil || *interfaceQueryResponse.Next.Get() == "" || len(interfaceQueryResponse.Results) == 0 {
-			break
-		}
-		offset += limit
-	}
-	return interfaceList, nil
-}
-
-func fetchDetailsFromDeviceList(input concourse.Input, deviceList []netbox.DeviceWithConfigContext, ctx context.Context) ([]concourse.Version, error) {
-	var (
-		interfaceList []netbox.Interface
-	)
-	output = make([]concourse.Version, 0, len(deviceList))
-
-	for _, d := range deviceList {
-		name := ""
-		if d.Name.IsSet() && d.Name.Get() != nil {
-			name = *d.Name.Get()
-		}
-		if serverInterfaceOptionIsSet(d, netboxFilter) {
-			interfaceList, err = runPagedInterfaceQuery(client, netboxFilter, d.Id, ctx)
-			if err != nil {
-				return nil, fmt.Errorf("error during server interface query: %w", err)
-			}
-
-			output, err = populateInterfaceDetails(name, input, d, interfaceList)
-			if err != nil {
-				return nil, fmt.Errorf("error during server interface details query: %w", err)
-			}
-		} else {
-			output, err = populateDeviceDetails(name, input, d)
-			if err != nil {
-				return nil, fmt.Errorf("error during device details query: %w", err)
-			}
-		}
-	}
-	// Sort the output by LastUpdated in ascending order
-	slices.SortStableFunc(output, func(a, b concourse.Version) int {
-		return strings.Compare(a.LastUpdated, b.LastUpdated)
-	})
-	return output, nil
-}
-
-func populateInterfaceDetails(name string, input concourse.Input, device netbox.DeviceWithConfigContext, interfaceList []netbox.Interface) ([]concourse.Version, error) {
-	for _, iface := range interfaceList {
-		lastUpdatedTime, referenceTime, err = getTimestamps(device, input)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing netbox timestamps because of: %w", err)
-		}
-
-		if lastUpdatedTime.UTC().After(referenceTime) {
-			configContext := ""
-			if input.Source.Filter.GetConfigContext != nil && *input.Source.Filter.GetConfigContext {
-				if device.HasConfigContext() {
-					configContextData := device.GetConfigContext()
-					if configContextBytes, err := json.Marshal(configContextData); err == nil {
-						configContext = string(configContextBytes)
-					}
-				}
-			}
-
-			deviceDisplayUrl := ""
-			if device.DisplayUrl != nil {
-				deviceDisplayUrl = *device.DisplayUrl
-			}
-
-			interfaceDisplayUrl := ""
-			if iface.DisplayUrl != nil {
-				interfaceDisplayUrl = *iface.DisplayUrl
-			}
-
-			output = append(output, concourse.Version{
-				Id:                  fmt.Sprintf("%d", iface.Id),
-				LastUpdated:         lastUpdatedTime.Format(time.RFC3339),
-				ObjectType:          "interfaces",
-				DeviceId:            fmt.Sprintf("%d", device.Id),
-				DeviceName:          name,
-				DeviceRole:          device.Role.GetSlug(),
-				DeviceApiUrl:        device.Url,
-				DeviceDisplayUrl:    deviceDisplayUrl,
-				ConfigContext:       configContext,
-				InterfaceName:       iface.Name,
-				InterfaceType:       string(iface.Type.GetLabel()),
-				InterfaceApiUrl:     iface.Url,
-				InterfaceDisplayUrl: interfaceDisplayUrl,
-			})
-		}
-	}
-	return output, nil
-}
-
-func populateDeviceDetails(name string, input concourse.Input, device netbox.DeviceWithConfigContext) ([]concourse.Version, error) {
-	lastUpdatedTime, referenceTime, err = getTimestamps(device, input)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing netbox timestamps because of: %w", err)
-	}
-
-	if lastUpdatedTime.UTC().After(referenceTime) {
-		configContext := ""
-		if input.Source.Filter.GetConfigContext != nil && *input.Source.Filter.GetConfigContext {
-			if device.HasConfigContext() {
-				configContextData := device.GetConfigContext()
-				if configContextBytes, err := json.Marshal(configContextData); err == nil {
-					configContext = string(configContextBytes)
-				}
-			}
-		}
-
-		displayUrl := ""
-		if device.DisplayUrl != nil {
-			displayUrl = *device.DisplayUrl
-		}
-
-		output = append(output, concourse.Version{
-			Id:               fmt.Sprintf("%d", device.Id),
-			LastUpdated:      lastUpdatedTime.Format(time.RFC3339),
-			ObjectType:       "devices",
-			DeviceName:       name,
-			DeviceRole:       device.Role.GetSlug(),
-			DeviceApiUrl:     device.Url,
-			DeviceDisplayUrl: displayUrl,
-			ConfigContext:    configContext,
-		})
-	}
-	return output, nil
-}
-
-func serverInterfaceOptionIsSet(device netbox.DeviceWithConfigContext, netboxFilter filter.NetboxObject) bool {
-	sIf := netboxFilter.ServerInterface
-	if device.Role.GetSlug() == "server" && (len(sIf.InterfaceId) > 0 ||
-		len(sIf.InterfaceName) > 0 ||
-		sIf.Enabled != nil ||
-		sIf.MgmtOnly != nil ||
-		sIf.Connected != nil ||
-		sIf.Cabled != nil ||
-		len(sIf.Type) > 0) {
-		return true
-	}
-	return false
-}
-
-func getReferenceTime(lastUpdated string) (time.Time, error) {
-	var (
-		referenceTime time.Time
-		err           error
-	)
-
-	if lastUpdated == "" {
-		return time.Time{}, nil
-	}
-
-	referenceTime, err = time.Parse(time.RFC3339, lastUpdated)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("invalid reference time format found in 'version.last_updated': %w", err)
-	} else {
-		return referenceTime.UTC(), nil
-	}
-}
-
-func getTimestamps(device any, input concourse.Input) (*time.Time, time.Time, error) {
-	switch device := device.(type) {
-	case netbox.DeviceWithConfigContext:
-		lastUpdatedTime = device.LastUpdated.Get()
-	case netbox.Interface:
-		lastUpdatedTime = device.LastUpdated.Get()
-	default:
-		return &time.Time{}, time.Time{}, fmt.Errorf("unexpected device type in getTimestamps: %T", device)
-	}
-	referenceTime, err = getReferenceTime(input.Version.LastUpdated)
-	if err != nil {
-		return &time.Time{}, time.Time{}, fmt.Errorf("error parsing netbox lastupdated timestamp because of: %w", err)
-	}
-	return lastUpdatedTime, referenceTime, nil
+func useChangelog(input concourse.Input) bool {
+	useChangelog := input.Source.UseChangelog != nil && *input.Source.UseChangelog
+	return useChangelog
 }

--- a/internal/netbox/query_test.go
+++ b/internal/netbox/query_test.go
@@ -59,11 +59,11 @@ func TestCreateQuery(t *testing.T) {
 
 			switch test.queryType {
 			case "dcimDevice":
-				query := createDeviceQuery(client, ConcourseSourceConfigObject.Source.Filter, ctx)
+				query := createDeviceQuery(client, ConcourseSourceConfigObject.Source.Filter, nil, ctx)
 				fieldInFilter = reflect.ValueOf(ConcourseSourceConfigObject.Source.Filter).FieldByName(test.filterName)
 				fieldInQuery = reflect.ValueOf(query).FieldByName(test.fieldName)
 			case "dcimInterface":
-				query := createInterfaceQuery(client, ConcourseSourceConfigObject.Source.Filter, ctx)
+				query := createInterfaceQuery(client, ConcourseSourceConfigObject.Source.Filter, nil, ctx)
 				fieldInFilter = reflect.ValueOf(ConcourseSourceConfigObject.Source.Filter.ServerInterface).FieldByName(test.filterName)
 				fieldInQuery = reflect.ValueOf(query).FieldByName(test.fieldName)
 			}

--- a/internal/netbox/region.go
+++ b/internal/netbox/region.go
@@ -1,0 +1,72 @@
+package netbox
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/netbox-community/go-netbox/v4"
+	"github.com/sapcc/concourse-netbox-resource/internal/filter"
+)
+
+// getUniqueRegions extracts unique region slugs from the site cache
+// If filter has specific regions, use those; otherwise extract from sites
+func getUniqueRegions(cache map[int32]string, netboxFilter filter.NetboxObject) []string {
+	if len(netboxFilter.RegionName) > 0 {
+		return netboxFilter.RegionName
+	}
+
+	regionSet := make(map[string]bool)
+	for _, region := range cache {
+		if region != "" {
+			regionSet[region] = true
+		}
+	}
+
+	regions := make([]string, 0, len(regionSet))
+	for region := range regionSet {
+		regions = append(regions, region)
+	}
+	return regions
+}
+
+func fetchSiteRegions(client *netbox.APIClient, netboxFilter filter.NetboxObject, ctx context.Context) (map[int32]string, error) {
+	cache := make(map[int32]string)
+	if client == nil {
+		return cache, nil
+	}
+
+	limit := int32(100)
+	offset := int32(0)
+	for {
+		query := client.DcimAPI.DcimSitesList(ctx).Limit(limit).Offset(offset)
+		if len(netboxFilter.RegionName) > 0 {
+			query = query.Region(netboxFilter.RegionName)
+		}
+		siteResponse, _, err := query.Execute()
+		if err != nil {
+			return nil, fmt.Errorf("error during DcimSitesList query: %w", err)
+		}
+		for _, site := range siteResponse.Results {
+			region := ""
+			if site.Region.IsSet() && site.Region.Get() != nil {
+				region = site.Region.Get().GetSlug()
+			}
+			cache[site.Id] = region
+		}
+		if !siteResponse.Next.IsSet() || siteResponse.Next.Get() == nil || *siteResponse.Next.Get() == "" || len(siteResponse.Results) == 0 {
+			break
+		}
+		offset += limit
+	}
+	return cache, nil
+}
+
+func getSiteRegion(siteId int32) string {
+	if siteRegionCache == nil {
+		return ""
+	}
+	if region, ok := siteRegionCache[siteId]; ok {
+		return region
+	}
+	return ""
+}


### PR DESCRIPTION
* `region_name`, `tenant` and `tag` properties added to the query filter
* `device_site`, `device_region` and `device_tags` properties added to the version output
* `use_changelog` option added to use the NetBox changelog. See the documentation for details and performance considerations
* `parallel_queries` option added to speed up the check process by running multiple queries in parallel
* golang version updated to `1.25.7`